### PR TITLE
Fix width issue with giscus

### DIFF
--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -23,3 +23,8 @@ input:-webkit-autofill,
 input:-webkit-autofill:focus {
   transition: background-color 600000s 0s, color 600000s 0s;
 }
+
+.giscus,
+.giscus-frame {
+  width: 100%;
+}


### PR DESCRIPTION
When the giscus component loads it is restricted to maybe 25% of page width. This CSS fixes the width issue.